### PR TITLE
Use max TLP instead of min when merging artifacts

### DIFF
--- a/thehive-backend/app/services/CaseMergeSrv.scala
+++ b/thehive-backend/app/services/CaseMergeSrv.scala
@@ -236,7 +236,7 @@ class CaseMergeSrv @Inject() (
           .set("dataType", firstArtifact.dataType())
           .set("message", concatOpt[Artifact](sameArtifacts, "\n  \n", a ⇒ caseMap(a.parentId.get).caseId(), _.message()))
           .set("startDate", firstDate(sameArtifacts.map(_.startDate())))
-          .set("tlp", JsNumber(sameArtifacts.map(_.tlp()).min))
+          .set("tlp", JsNumber(sameArtifacts.map(_.tlp()).max))
           .set("tags", JsArray(sameArtifacts.flatMap(_.tags()).distinct.map(JsString)))
           .set("ioc", JsBoolean(sameArtifacts.map(_.ioc()).reduce(_ || _)))
           .set("status", mergeArtifactStatus(sameArtifacts))


### PR DESCRIPTION
This pull request fixes behavior described in #443.