### PR TITLE
Fix typo in attribute name

### DIFF
--- a/thehive-backend/app/models/Alert.scala
+++ b/thehive-backend/app/models/Alert.scala
@@ -94,7 +94,7 @@ class AlertModel @Inject() (dblists: DBLists)
           attrs
         else {
           val hasher = Hasher("MD5")
-          val tpe = (attrs \ "tpe").asOpt[String].getOrElse("<null>")
+          val tpe = (attrs \ "type").asOpt[String].getOrElse("<null>")
           val source = (attrs \ "source").asOpt[String].getOrElse("<null>")
           val sourceRef = (attrs \ "sourceRef").asOpt[String].getOrElse("<null>")
           val _id = hasher.fromString(s"$tpe|$source|$sourceRef").head.toString()


### PR DESCRIPTION
Seems there is a type in Alert model when generating the alert id making the `type` attribute used when generating the MD5 hash always the string `<null>`.

When using `{"type":"test", "source":"me", "sourceRef":"testing"}` as attributes to generate the alert id, we should obtain `a926dd8c6340a4e295c8cd5b6aa6fd84` (md5 hash of `test|me|testing`) but instead got `ec9572cfe6f826117fdabadfa00da645` which is the md5 hash of `<null>|me|testing`

This should fix #457.