### PR TITLE
Add ElasticSearch file descriptor limit to docker-compose.yml

### DIFF
--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - thread_pool.index.queue_size=100000
       - thread_pool.search.queue_size=100000
       - thread_pool.bulk.queue_size=100000
+    ulimits:
+      nofile:
+      soft: 65536
+      hard: 65536
   cortex:
     image: certbdf/cortex:latest
     ports:


### PR DESCRIPTION
(Related to https://github.com/TheHive-Project/TheHiveDocs/pull/38)

Hi,

When setting up a test instance of TheHive using the provided docker-compose.yml, I received some errors from the ElasticSearch container: in order to run in Production mode, it requires a minimum of 65k file descriptors as the docker ulimit.

Submitting in the hopes that this might save the next person setting up an instance 5 mins. Hope that's okay -- feel free to reject or change if this is not the right place to add the changes.

Regards