### PR TITLE
Update spacing for elasticsearch section in docker-compose yml file

### DIFF
--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - thread_pool.bulk.queue_size=100000
     ulimits:
       nofile:
-      soft: 65536
-      hard: 65536
+        soft: 65536
+        hard: 65536
   cortex:
     image: certbdf/cortex:latest
     depends_on:


### PR DESCRIPTION
This commit fixes the spacing in the elasticsearch section of the
docker-compose.yml file, making the file syntactically valid yaml.