### PR TITLE
289 - support case template task log template verbiage

### DIFF
--- a/thehive-backend/app/models/Task.scala
+++ b/thehive-backend/app/models/Task.scala
@@ -23,6 +23,7 @@ object TaskStatus extends Enumeration with HiveEnumeration {
 trait TaskAttributes { _: AttributeDef ⇒
   val title = attribute("title", F.textFmt, "Title of the task")
   val description = optionalAttribute("description", F.textFmt, "Task details")
+  val template = optionalAttribute("template", F.textFmt, "Task Log Template")
   val owner = optionalAttribute("owner", F.userFmt, "User who owns the task")
   val status = attribute("status", F.enumFmt(TaskStatus), "Status of the task", TaskStatus.Waiting)
   val flag = attribute("flag", F.booleanFmt, "Flag of the task", false)

--- a/ui/app/scripts/controllers/case/CaseTasksItemCtrl.js
+++ b/ui/app/scripts/controllers/case/CaseTasksItemCtrl.js
@@ -11,7 +11,7 @@
 
             $scope.loading = false;
             $scope.newLog = {
-                message: ''
+                message: (task.template != undefined) ? task.template : ''
             };
             $scope.sortOptions = {
                 '+startDate': 'Oldest first',
@@ -113,7 +113,7 @@
                 }, $scope.newLog, function () {
                     delete $scope.newLog.attachment;
                     $scope.state.attachmentCollapsed = true;
-                    $scope.newLog.message = '';
+                    $scope.newLog.message = ($scope.task.template != undefined) ? $scope.task.template : '';
 
                     $rootScope.markdownEditorObjects.newLog.hidePreview();
                     $scope.adding = false;

--- a/ui/app/views/partials/admin/case-templates.task.html
+++ b/ui/app/views/partials/admin/case-templates.task.html
@@ -20,11 +20,19 @@
             </div>
         </div>
 
+        <div class="form-group" ng-class="{ 'has-error' : taskForm.template.$invalid && !taskForm.template.$pristine }">
+            <label class="col-md-3 control-label">Task Log template</label>
+            <div class="col-md-9">
+                <markdown-editor content="task.template"></markdown-editor>
+                <p class="help-block small">Task Log default verbiage</p>
+            </div>
+        </div>
+
         <div class="form-group">
             <label class="col-md-3 control-label">Assignee</label>
             <div class="col-md-9">
                 <select class="form-control" ng-model="task.owner"
-                    ng-options="item.id as item.name for item in users | orderBy:'id'"></select>                
+                    ng-options="item.id as item.name for item in users | orderBy:'id'"></select>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Per Issue #289, Tasks defined within Case Templates should support Task Log Templates to help provide boilerplate verbiage for a given task. This PR adds supports for Case Template Task Log Templates.