### PR TITLE
flag for Windows env

### DIFF
--- a/project/FrontEnd.scala
+++ b/project/FrontEnd.scala
@@ -25,13 +25,15 @@ object FrontEnd extends AutoPlugin {
 
     frontendFiles := {
       val s = streams.value
+      val ext = if (System.getProperty("os.name").toLowerCase().contains("windows")) ".cmd" else ""
+
       s.log.info("Preparing front-end for prod ...")
-      s.log.info("npm install")
-      Process("npm" :: "install" :: Nil, baseDirectory.value / "ui") ! s.log
-      s.log.info("bower install")
-      Process("bower" :: "install" :: Nil, baseDirectory.value / "ui") ! s.log
-      s.log.info("grunt build")
-      Process("grunt" :: "build" :: Nil, baseDirectory.value / "ui") ! s.log
+      s.log.info(s"npm$ext install")
+      Process(s"npm$ext" :: "install" :: Nil, baseDirectory.value / "ui") ! s.log
+      s.log.info(s"bower$ext install")
+      Process(s"bower$ext" :: "install" :: Nil, baseDirectory.value / "ui") ! s.log
+      s.log.info(s"grunt$ext build")
+      Process(s"grunt$ext" :: "build" :: Nil, baseDirectory.value / "ui") ! s.log
       val dir = baseDirectory.value / "ui" / "dist"
       (dir.**(AllPassFilter)) pair rebase(dir, "ui")
     })


### PR DESCRIPTION
This commit helps to address Issue #602 related to building TheHive on Windows. This code will detect windows being used and if found, add a ".cmd" to the npm, bower, and grunt commands. 

I was able to successfully build TheHive with this modification coupled with the latest compilation of elastic4play.