### PR TITLE
fix bug in AlertListCtrl

### DIFF
--- a/ui/app/scripts/controllers/alert/AlertListCtrl.js
+++ b/ui/app/scripts/controllers/alert/AlertListCtrl.js
@@ -222,11 +222,11 @@
                   })
                   .catch(function(err) {
                       NotificationSrv.error('AlertList', response.data, response.status);
-                  })
+                  });
             };
 
             this.runResponder = function(responderId, event) {
-                CortexSrv.runResponder(responderId, 'alert', _.pick(event, 'id', 'tlp', ))
+                CortexSrv.runResponder(responderId, 'alert', _.pick(event, 'id', 'tlp'))
                   .then(function(response) {
                       NotificationSrv.log(['Responder', response.data.responderName, 'started successfully on alert', event.title].join(' '), 'success');
                   })


### PR DESCRIPTION
Fix bug in AlertListCtrl that is preventing compilation of ui in the 'develop' branch.

Error:
```
[info] Generating ".tmp/concat/scripts/scripts.js" from: ".tmp/concat/scripts/scripts.js"...ERROR
[info] >> error: couldn't process source due to parse error
[info] >> Unexpected token (2676:88)
[info] Warning: Task "ngAnnotate:dist" failed. Use --force to continue.
[info] Aborted due to warnings.
```

