### PR TITLE
Move input group addons from right to left for better usage

### DIFF
--- a/ui/app/views/partials/case/case.merge.html
+++ b/ui/app/views/partials/case/case.merge.html
@@ -3,6 +3,10 @@
 </div>
 <div class="modal-body merge-dialog">
     <div class="input-group input-group-lg search-field">
+        <span class="input-group-addon">
+            <input type="radio" name="search-type" ng-model="dialog.search.type" value="title" ng-change="dialog.onTypeChange('title')"> By Title
+            <input type="radio" name="search-type" ng-model="dialog.search.type" value="number" ng-change="dialog.onTypeChange('number')"> By Number
+        </span>
         <input type="text"
             placeholder="{{dialog.search.placeholder}}"
             ng-model="dialog.search.input"
@@ -11,12 +15,6 @@
             typeahead-min-length="dialog.search.minInputLength"
             typeahead-on-select="dialog.onSelect($item)"
             class="form-control">
-
-        <span class="input-group-addon">
-            <input type="radio" name="search-type" ng-model="dialog.search.type" value="title" ng-change="dialog.onTypeChange('title')"> By Title
-            <input type="radio" name="search-type" ng-model="dialog.search.type" value="number" ng-change="dialog.onTypeChange('number')"> By Number
-        </span>
-
     </div>
 
     <div class="empty-message mv-s" ng-show="dialog.search.cases.length === 0">


### PR DESCRIPTION
This is a minor UI change proposal for better ergonomics.

Currently, when you want to merge two cases together you open the merge modal, enter the title of the case to be merged in, select the right case in the proposals and click and voilà!

Buuut when all you remember is the case number you type the case number, realize that this is not the title, change the radio button to "By title" an type (again) the case number to find the right case to be merged in.

Having the input addons on the left of the input would ease this workflow (at least for left-to-right readers) since we would first read the two selection options (by title or by case number) before entering anything in the input field.

So, currently, we have this:
![currently](https://user-images.githubusercontent.com/3243772/43965672-2aa409a4-9cc0-11e8-973b-d23095633ae3.PNG)

An I suggest to have this instead:
![proposal](https://user-images.githubusercontent.com/3243772/43965685-33966476-9cc0-11e8-8cfa-b2ed60952789.PNG)

