### PR TITLE
Automatation to show all the correlated IOCs between an open Case and MISP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 **Fixed bugs:**
 
+- Error when uploading password protected zips as observables [\#805](https://github.com/TheHive-Project/TheHive/issues/805)
 - Lowercase user ID coming from HTTP header [\#808](https://github.com/TheHive-Project/TheHive/issues/808)
 
 ## [3.2.0-RC1](https://github.com/TheHive-Project/TheHive/tree/3.2.0-RC1) (2018-11-16)

--- a/rpm.sbt
+++ b/rpm.sbt
@@ -9,7 +9,7 @@ version in Rpm := {
 }
 rpmRelease := {
   version.value match {
-    case stableVersion(_, _) => version.value
+    case stableVersion(_, v2) => v2
     case betaVersion(v1, v2) => "0.1RC" + v2
     case _ => sys.error("Invalid version: " + version.value)
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.0"
+version in ThisBuild := "3.2.0-1"


### PR DESCRIPTION
When open a case and add observables (e.g., Filename), it would be very nice if TheHive automatically query MISP about that observable and pull all the IOCc on the events that include this Filename and give the option to include them in the opened case. It could accelerate the analysis process because TheHive will bring all IOCs from MISP together.