### PR TITLE
OpenID Connect and OAuth2 sign-on improvement

### DIFF
--- a/conf/application.sample
+++ b/conf/application.sample
@@ -45,57 +45,109 @@ search {
 
 # Authentication
 auth {
-	# "provider" parameter contains authentication provider. It can be multi-valued (useful for migration)
-	# available auth types are:
-	# services.LocalAuthSrv : passwords are stored in user entity (in Elasticsearch). No configuration is required.
-	# ad : use ActiveDirectory to authenticate users. Configuration is under "auth.ad" key
-	# ldap : use LDAP to authenticate users. Configuration is under "auth.ldap" key
-	provider = [local]
+  # "provider" parameter contains authentication provider. It can be multi-valued (useful for migration)
+  # available auth types are:
+  # services.LocalAuthSrv : passwords are stored in user entity (in Elasticsearch). No configuration is required.
+  # ad : use ActiveDirectory to authenticate users. Configuration is under "auth.ad" key
+  # ldap : use LDAP to authenticate users. Configuration is under "auth.ldap" key
+  # oauth2 : use OAuth/OIDC to authenticate users. Configuration is under "auth.oauth2" and "auth.sso" keys
+  provider = [local]
 
   # By default, basic authentication is disabled. You can enable it by setting "method.basic" to true.
   #method.basic = true
 
+  ad {
+    # The Windows domain name in DNS format. This parameter is required if you do not use
+    # 'serverNames' below.
+    #domainFQDN = "mydomain.local"
 
-	ad {
-		# The Windows domain name in DNS format. This parameter is required if you do not use
-		# 'serverNames' below.
-		#domainFQDN = "mydomain.local"
+    # Optionally you can specify the host names of the domain controllers instead of using 'domainFQDN
+    # above. If this parameter is not set, TheHive uses 'domainFQDN'.
+    #serverNames = [ad1.mydomain.local, ad2.mydomain.local]
 
-		# Optionally you can specify the host names of the domain controllers instead of using 'domainFQDN
-		# above. If this parameter is not set, TheHive uses 'domainFQDN'.
-        #serverNames = [ad1.mydomain.local, ad2.mydomain.local]
+    # The Windows domain name using short format. This parameter is required.
+    #domainName = "MYDOMAIN"
 
-		# The Windows domain name using short format. This parameter is required.
-		#domainName = "MYDOMAIN"
+    # If 'true', use SSL to connect to the domain controller.
+    #useSSL = true
+  }
 
-		# If 'true', use SSL to connect to the domain controller.
-		#useSSL = true
-	}
+  ldap {
+    # The LDAP server name or address. The port can be specified using the 'host:port'
+    # syntax. This parameter is required if you don't use 'serverNames' below.
+    #serverName = "ldap.mydomain.local:389"
 
-	ldap {
-		# The LDAP server name or address. The port can be specified using the 'host:port'
-		# syntax. This parameter is required if you don't use 'serverNames' below.
-		#serverName = "ldap.mydomain.local:389"
+    # If you have multiple LDAP servers, use the multi-valued setting 'serverNames' instead.
+    #serverNames = [ldap1.mydomain.local, ldap2.mydomain.local]
 
-		# If you have multiple LDAP servers, use the multi-valued setting 'serverNames' instead.
-        #serverNames = [ldap1.mydomain.local, ldap2.mydomain.local]
+    # Account to use to bind to the LDAP server. This parameter is required.
+    #bindDN = "cn=thehive,ou=services,dc=mydomain,dc=local"
 
-		# Account to use to bind to the LDAP server. This parameter is required.
-		#bindDN = "cn=thehive,ou=services,dc=mydomain,dc=local"
+    # Password of the binding account. This parameter is required.
+    #bindPW = "***secret*password***"
 
-		# Password of the binding account. This parameter is required.
-		#bindPW = "***secret*password***"
+    # Base DN to search users. This parameter is required.
+    #baseDN = "ou=users,dc=mydomain,dc=local"
 
-		# Base DN to search users. This parameter is required.
-		#baseDN = "ou=users,dc=mydomain,dc=local"
+    # Filter to search user in the directory server. Please note that {0} is replaced
+    # by the actual user name. This parameter is required.
+    #filter = "(cn={0})"
 
-		# Filter to search user in the directory server. Please note that {0} is replaced
-		# by the actual user name. This parameter is required.
-		#filter = "(cn={0})"
+    # If 'true', use SSL to connect to the LDAP directory server.
+    #useSSL = true
+  }
 
-		# If 'true', use SSL to connect to the LDAP directory server.
-		#useSSL = true
-	}
+  oauth2 {
+    # URL of the authorization server
+    #clientId = "client-id"
+    #clientSecret = "client-secret"
+    #redirectUri = "https://my-thehive-instance.example/index.html#!/login"
+    #responseType = "code"
+    #grantType = "authorization_code"
+
+    # URL from where to get the access token
+    #authorizationUrl = "https://auth-site.com/OAuth/Authorize"
+    #tokenUrl = "https://auth-site.com/OAuth/Token"
+
+    # The endpoint from which to obtain user details using the OAuth token, after successful login
+    #userUrl = "https://auth-site.com/api/User"
+    #scope = "openid profile"
+  }
+
+  # Single-Sign On
+  sso {
+    # Autocreate user in database?
+    #autocreate = false
+
+    # Autoupdate its profile and roles?
+    #autoupdate = false
+
+    # Autologin user using SSO?
+    #autologin = false
+    # Attributes mappings
+    #attributes {
+    #  login = "sub"
+    #  name = "name"
+    #  groups = "groups"
+    #  #roles = "roles"
+    #}
+
+    # Name of mapping class from user resource to backend user ('simple' or 'group')
+    #mapper = group
+    # Default roles for users with no groups mapped ("read", "write", "admin")
+    #defaultRoles = []
+
+    #groups {
+    #  # URL to retreive groups (leave empty if you are using OIDC)
+    #  #url = "https://auth-site.com/api/Groups"
+    #  # Group mappings, you can have multiple roles for each group: they are merged
+    #  mappings {
+    #    admin-profile-name = ["admin"]
+    #    editor-profile-name = ["write"]
+    #    reader-profile-name = ["read"]
+    #  }
+    #}
+  }
 }
 
 # Maximum time between two requests without requesting authentication

--- a/conf/application.sample
+++ b/conf/application.sample
@@ -124,6 +124,7 @@ auth {
 
     # Autologin user using SSO?
     #autologin = false
+
     # Attributes mappings
     #attributes {
     #  login = "sub"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -46,6 +46,11 @@
     <!--logger name="services.LocalStreamActor" level="DEBUG" /-->
     <!--logger name="services.StreamActor" level="DEBUG" /-->
 
+    <!-- Uncomment the next lines to log debug information for OAuth/OIDC login -->
+    <!--logger name="org.elastic4play.services.auth" level="DEBUG" /-->
+    <!--logger name="services.OAuth2Srv" level="DEBUG" /-->
+    <!--logger name="services.mappers" level="DEBUG" /-->
+
     <root level="INFO">
         <appender-ref ref="ASYNCFILE" />
         <appender-ref ref="ASYNCSTDOUT" />

--- a/thehive-backend/app/services/mappers/GroupUserMapper.scala
+++ b/thehive-backend/app/services/mappers/GroupUserMapper.scala
@@ -3,8 +3,9 @@ package services.mappers
 import javax.inject.Inject
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.parsing.combinator._
 
-import play.api.Configuration
+import play.api.{Configuration, Logger}
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 
@@ -38,13 +39,73 @@ class GroupUserMapper(
 
   override val name: String = "group"
 
-  override def getUserFields(jsValue: JsValue, authHeader: Option[(String, String)]): Future[Fields] = {
+  private[GroupUserMapper] lazy val logger = Logger(getClass)
 
-    val apiCall = authHeader.fold(ws.url(groupsUrl))(headers ⇒ ws.url(groupsUrl).addHttpHeaders(headers))
-    apiCall.get.flatMap { r ⇒
-      val jsonGroups  = (r.json \ groupAttrName).as[Seq[String]]
-      val mappedRoles = jsonGroups.flatMap(mappings.get).maxBy(_.length)
-      val roles       = if (mappedRoles.nonEmpty) mappedRoles else defaultRoles
+  private class RoleListParser extends RegexParsers {
+    val str     = "[a-zA-Z0-9_]+".r
+    val strSpc  = "[a-zA-Z0-9_ ]+".r
+    val realStr = ("\""~>strSpc<~"\"" | "'"~>strSpc<~"'" | str)
+
+    def expr: Parser[Seq[String]] = {
+      "[" ~ opt(realStr ~ rep(("," | ",") ~ realStr)) ~ "]" ^^ {
+        case _ ~ Some(firstRole ~ list) ~ _ => list.foldLeft(Seq(firstRole)) {
+          case (queue, _ ~ role) => role +: queue
+        }
+        case _ ~ _      => Seq.empty[String]
+      } | opt(realStr) ^^ {
+        case Some(role) => Seq(role)
+        case None       => Seq.empty[String]
+      }
+    }
+
+    def apply(input: String, logger: Logger): Seq[String] = parseAll(expr, input) match {
+      case Success(result, _)  => result
+      case failure : NoSuccess => {
+        logger.error(failure.msg)
+        Seq.empty[String]
+      }
+    }
+  }
+
+  override def getUserFields(jsValue: JsValue, authHeader: Option[(String, String)]): Future[Fields] = {
+    if (groupsUrl == "") {
+      logger.debug(s"No groups endpoint provided (auth.sso.groups.url). Assuming groups were already received.")
+
+      val jsonGroups: Seq[String] = {
+        val groups: JsValue = (jsValue \ groupAttrName).get
+        // Groups received as valid JSON array
+        if (groups.isInstanceOf[JsArray]) {
+          groups.as[Seq[String]]
+        // Group list received as string (invalid JSON, for example: "ROLE" or "['Role 1', ROLE2, 'Role_3']")
+        } else if (groups.isInstanceOf[JsString]) {
+          (new RoleListParser).apply(groups.as[String], logger)
+        // Invalid group list
+        } else {
+          logger.error(s"Invalid group list (${groupAttrName} attribute, value '${groups}', type ${groups.getClass})")
+          Seq.empty[String]
+        }
+      }
+
+      mapGroupsAndBuildUserFields(jsValue, jsonGroups)
+
+    } else {
+      val apiCall = authHeader.fold(ws.url(groupsUrl))(headers ⇒ ws.url(groupsUrl).addHttpHeaders(headers))
+      apiCall.get.flatMap { r ⇒
+        val jsonGroups = (r.json \ groupAttrName).as[Seq[String]]
+        mapGroupsAndBuildUserFields(jsValue, jsonGroups)
+      }
+    }
+  }
+
+  private def mapGroupsAndBuildUserFields(jsValue: JsValue, jsonGroups: Seq[String]): Future[Fields] = {
+    val mappedRoles = jsonGroups.flatMap(mappings.get).flatten.toSet
+    val roles       = if (mappedRoles.nonEmpty) mappedRoles else defaultRoles
+
+    if (roles.isEmpty) {
+      Future.failed(AuthenticationError(s"No matched roles for user."))
+
+    } else {
+      logger.debug(s"Computed roles : ${roles}")
 
       val fields = for {
         login ← (jsValue \ loginAttrName).validate[String]

--- a/thehive-backend/app/services/mappers/GroupUserMapper.scala
+++ b/thehive-backend/app/services/mappers/GroupUserMapper.scala
@@ -15,7 +15,6 @@ import org.elastic4play.controllers.Fields
 class GroupUserMapper(
     loginAttrName: String,
     nameAttrName: String,
-    rolesAttrName: Option[String],
     groupAttrName: String,
     defaultRoles: Seq[String],
     groupsUrl: String,
@@ -26,9 +25,8 @@ class GroupUserMapper(
 
   @Inject() def this(configuration: Configuration, ws: WSClient, ec: ExecutionContext) =
     this(
-      configuration.getOptional[String]("auth.sso.attributes.login").getOrElse("name"),
-      configuration.getOptional[String]("auth.sso.attributes.name").getOrElse("username"),
-      configuration.getOptional[String]("auth.sso.attributes.roles"),
+      configuration.getOptional[String]("auth.sso.attributes.login").getOrElse("sub"),
+      configuration.getOptional[String]("auth.sso.attributes.name").getOrElse("name"),
       configuration.getOptional[String]("auth.sso.attributes.groups").getOrElse(""),
       configuration.getOptional[Seq[String]]("auth.sso.defaultRoles").getOrElse(Seq()),
       configuration.getOptional[String]("auth.sso.groups.url").getOrElse(""),

--- a/thehive-backend/app/services/mappers/SimpleUserMapper.scala
+++ b/thehive-backend/app/services/mappers/SimpleUserMapper.scala
@@ -20,8 +20,8 @@ class SimpleUserMapper(
 
   @Inject() def this(configuration: Configuration, ec: ExecutionContext) =
     this(
-      configuration.getOptional[String]("auth.sso.attributes.login").getOrElse("name"),
-      configuration.getOptional[String]("auth.sso.attributes.name").getOrElse("username"),
+      configuration.getOptional[String]("auth.sso.attributes.login").getOrElse("sub"),
+      configuration.getOptional[String]("auth.sso.attributes.name").getOrElse("name"),
       configuration.getOptional[String]("auth.sso.attributes.roles"),
       configuration.getOptional[Seq[String]]("auth.sso.defaultRoles").getOrElse(Seq()),
       ec

--- a/thehive-backend/app/services/mappers/SimpleUserMapper.scala
+++ b/thehive-backend/app/services/mappers/SimpleUserMapper.scala
@@ -37,7 +37,7 @@ class SimpleUserMapper(
     } yield Fields(Json.obj("login" → login, "name" → name, "roles" → roles))
     fields match {
       case JsSuccess(f, _) ⇒ Future.successful(f)
-      case JsError(errors) ⇒ Future.failed(AuthenticationError(s"User info fails: ${errors.map(_._1).mkString}"))
+      case JsError(errors) ⇒ Future.failed(AuthenticationError(s"User info fails: ${errors.map(_._2).map(_.map(_.messages.mkString(", ")).mkString("; ")).mkString}"))
     }
   }
 }

--- a/ui/app/scripts/app.js
+++ b/ui/app/scripts/app.js
@@ -58,7 +58,7 @@ angular.module('thehive', [
                     }
                 },
                 params: {
-                    autoLogin: false
+                    disableSsoAutoLogin: false
                 },
                 title: 'Login'
             })

--- a/ui/app/scripts/controllers/RootCtrl.js
+++ b/ui/app/scripts/controllers/RootCtrl.js
@@ -9,7 +9,7 @@ angular.module('theHiveControllers').controller('RootCtrl',
             $state.go('maintenance');
             return;
         }else if(!currentUser || !currentUser.id) {
-            $state.go('login', {autoLogin: appConfig.config.ssoAutoLogin });
+            $state.go('login');
             return;
         }
 
@@ -141,7 +141,7 @@ angular.module('theHiveControllers').controller('RootCtrl',
 
         $scope.logout = function() {
             AuthenticationSrv.logout(function() {
-                $state.go('login');
+                $state.go('login', {disableSsoAutoLogin: true});
             }, function(data, status) {
                 NotificationSrv.error('RootCtrl', data, status);
             });

--- a/ui/app/scripts/services/UtilsSrv.js
+++ b/ui/app/scripts/services/UtilsSrv.js
@@ -101,23 +101,6 @@
                         scope.value = scope.oldValue;
                         scope.updatable.updating = false;
                     };
-                },
-
-                extractQueryParam: function(paramName, queryString) {
-                    if (!queryString || !paramName) {
-                        return;
-                    }
-
-                    var param = $location.search()[paramName];
-
-                    if (param) {
-                        return param;
-                    } else {
-                        var parsedQuery = _.find(queryString.split('&'), function(str) {
-                            return str.startsWith(paramName + '=');
-                        });
-                        return parsedQuery ? parsedQuery.substr(paramName.length + 1) : undefined;
-                    }
                 }
             };
 

--- a/ui/app/views/login.html
+++ b/ui/app/views/login.html
@@ -6,25 +6,25 @@
         <p class="login-box-msg">Sign in to start your session</p>
         <form name="loginForm">
             <div class="form-group has-feedback has-feedback-left">
-                 <input type="text" class="form-control" placeholder="Login" ng-model="params.username" autocomplete="off" required>
+                 <input type="text" class="form-control" placeholder="Login" ng-model="params.username" autocomplete="off" required ng-disabled="ssoLogingIn">
                  <i class="form-control-feedback glyphicon glyphicon-user"></i>
             </div>
             <div class="form-group has-feedback has-feedback-left">
-                <input type="password" class="input form-control" placeholder="Password" ng-model="params.password" autocomplete="off" required>
+                <input type="password" class="input form-control" placeholder="Password" ng-model="params.password" autocomplete="off" required ng-disabled="ssoLogingIn">
                 <i class="form-control-feedback glyphicon glyphicon-lock "></i>
             </div>
 
             <div class="row">
                 <div class="col-xs-offset-8 col-xs-4">
-                    <button type="submit" ng-click="login()" class="btn btn-primary btn-sm btn-block btn-flat" ng-disabled="loginForm.$invalid">Sign In</button>
+                    <button type="submit" ng-click="login()" class="btn btn-primary btn-sm btn-block btn-flat" ng-disabled="loginForm.$invalid || ssoLogingIn">Sign In</button>
                 </div>
             </div>
         </form>
     </div>
     <div class="sso-login-box" ng-if="::ssoEnabled()">
         <div class="row">
-            <div class="col-xs-offset-4 col-xs-4">
-                <button type="submit" class="btn btn-success btn-sm btn-block btn-flat" ng-click="ssoLogin()">Sign In with SSO</button>
+            <div class="col-xs-6" style="margin: 0 auto; float: none;">
+		    <button type="submit" class="btn btn-sm btn-flat" ng-class="{'btn-warning': ssoLogingIn, 'btn-success': !ssoLogingIn}" ng-click="ssoLogin()" ng-disabled="ssoLogingIn">{{ ssoLogingIn ? "Signing in with SSO..." : "Sign in with SSO" }}</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This patch fixes #1110.

## Bug fixes
- `Invalid URL` on groups parsing (mentionned in #1010)
- `Authentication failure` (#946)
- `Authentication failure` on disconnection
- SSO auto-login not working

## Improvements
- SSO login now supports:
  - Groups parsing from user info (fixes the `Invalid URL` error)
  - Auto-login
  - Auto-updating user profile
- Default config parameters are following OpenID conventions
- The OAuth2 code is now removed from the URL after SSO signing in (fixes `Authentication failure` on disconnection)

In addition, I improved the login form when SSO signing in. Before this commit, nothing was displayed indicating that we were signing in using SSO. Now, when we are redirected to TheHive after signing on our federated identity provider, TheHive disables the login form and change button message to indicate that a SSO signing in is currently performed. The following image shows this feature:

![image](https://user-images.githubusercontent.com/1888635/64170567-b58af880-ce50-11e9-85f2-9d4ef3734a43.png)

Finally, a user with no matched roles (using the `group` mapper) can't SSO sign in. An `AuthenticationError` will be raised. This is needed in case of an internal user wants to access TheHive but should not: this user will match no profiles (read, write, admin).

PS: I will submit another PR on TheHiveDocs to explain how to configure SSO login.