### PR TITLE
Revert Docker-Compose.yml to Stable Release

### DIFF
--- a/docker/thehive/data/.gitignore
+++ b/docker/thehive/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -5,21 +5,19 @@ services:
     environment:
       - http.host=0.0.0.0
       - cluster.name=hive
-      - thread_pool.index.queue_size=100000
+      - xpack.security.enabled=false
       - thread_pool.search.queue_size=100000
-      - thread_pool.bulk.queue_size=100000
+      - gateway.recover_after_nodes=1
     ulimits:
       nofile:
         soft: 65536
         hard: 65536
   cortex:
-    image: thehiveproject/cortex:3.0.0-RC4
-    depends_on:
-      - elasticsearch
+    image: thehiveproject/cortex:3.0.0
     ports:
       - "0.0.0.0:9001:9001"
   thehive:
-    image: thehiveproject/thehive:3.4.0-RC2
+    image: thehiveproject/thehive:3.4.0
     depends_on:
       - elasticsearch
       - cortex

--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -2,6 +2,8 @@ version: "2"
 services:
   elasticsearch:
     image: elasticsearch:6.8.0
+    volumes:
+      - ./data:/usr/share/elasticsearch/data
     environment:
       - http.host=0.0.0.0
       - cluster.name=hive

--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         hard: 65536
   cortex:
     image: thehiveproject/cortex:3.0.0
+    depends_on:
+      - elasticsearch
     ports:
       - "0.0.0.0:9001:9001"
   thehive:

--- a/docker/thehive/docker-compose.yml
+++ b/docker/thehive/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     environment:
       - http.host=0.0.0.0
       - cluster.name=hive
-      - xpack.security.enabled=false
       - thread_pool.search.queue_size=100000
       - gateway.recover_after_nodes=1
     ulimits:


### PR DESCRIPTION
The current [docker-compose.yaml](https://github.com/TheHive-Project/TheHive/blob/master/docker/thehive/docker-compose.yml) file is utilizing versions of The Hive and Cortex that were incompatible with the ElasticSearch container.

Removing specific version number in favor of latest release achieves stability and reliable connection with ElasticSearch.

# Changes
- Revert thehiveproject/cortex:3.0.0 => thehiveproject/cortex
- Revert thehiveproject/thehive:3.4.0-RC2 => thehiveproject/thehive
- Removed deprecated environment variables `threadpool.*.queue_size`
- Added `gateway.recover_after_nodes` var to ElasticSearch to ensure recovery after failure
- Added default `data` volume for data persistence between deployments