### PR TITLE
Fix observable tagging for MISP export

### DIFF
--- a/thehive-misp/app/connectors/misp/JsonFormat.scala
+++ b/thehive-misp/app/connectors/misp/JsonFormat.scala
@@ -82,7 +82,7 @@ object JsonFormat {
       "type"     → attribute.tpe,
       "value"    → attribute.value.fold[String](identity, _.name),
       "comment"  → attribute.comment,
-      "Tag"      → Json.arr(Json.obj("name" → tlpWrites.writes(attribute.tlp)))
+      "Tag" → JsArray((attribute.tags.map(JsString.apply) :+ tlpWrites.writes(attribute.tlp)).map(t ⇒ Json.obj("name" -> t)))
     )
   }
 

--- a/thehive-misp/app/connectors/misp/MispConfig.scala
+++ b/thehive-misp/app/connectors/misp/MispConfig.scala
@@ -59,7 +59,8 @@ class MispConfig(val interval: FiniteDuration, val connections: Seq[MispConnecti
         excludedTags,
         whitelistTags,
         purpose,
-        exportCaseTags
+        exportCaseTags,
+        exportAttributeTags
       )
     )
 

--- a/thehive-misp/app/connectors/misp/MispConnection.scala
+++ b/thehive-misp/app/connectors/misp/MispConnection.scala
@@ -29,7 +29,8 @@ case class MispConnection(
     excludedTags: Set[String],
     whitelistTags: Set[String],
     purpose: MispPurpose.Value,
-    exportCaseTags: Boolean
+    exportCaseTags: Boolean,
+    exportAttributeTags: Boolean
 ) {
 
   private[MispConnection] lazy val logger = Logger(getClass)

--- a/thehive-misp/app/connectors/misp/MispModel.scala
+++ b/thehive-misp/app/connectors/misp/MispModel.scala
@@ -40,6 +40,7 @@ case class ExportedMispAttribute(
     artifact: Artifact,
     tpe: String,
     category: String,
+    tags: Seq[String],
     tlp: Long,
     value: Either[String, Attachment],
     comment: Option[String]

--- a/thehive-misp/app/connectors/misp/MispSrv.scala
+++ b/thehive-misp/app/connectors/misp/MispSrv.scala
@@ -109,7 +109,7 @@ class MispSrv @Inject()(
             logger.error(s"Artifact $artifact has neither data nor attachment")
             sys.error("???")
         }
-        ExportedMispAttribute(artifact, tpe, category, artifact.tlp(), value, artifact.message())
+        ExportedMispAttribute(artifact, tpe, category, artifact.tags(), artifact.tlp(), value, artifact.message())
       }
       .runWith(Sink.seq)
   }


### PR DESCRIPTION
Allows observable tags to be exported to MISP attributes. Addresses #508 