### PR TITLE
Fixed application.sample.conf file name

### DIFF
--- a/package.sbt
+++ b/package.sbt
@@ -4,7 +4,7 @@ import Common.remapPath
 mappings in Universal ~= {
   _.flatMap {
     case (_, "conf/application.conf")                => Nil
-    case (file, "conf/application.sample.conf.conf") => Seq(file -> "conf/application.conf")
+    case (file, "conf/application.sample.conf") => Seq(file -> "conf/application.conf")
     case (_, "conf/logback.xml")                     => Nil
     case other                                       => Seq(other)
   } ++ Seq(


### PR DESCRIPTION
Don't think it should be mapping this file with a .conf.conf extension - unless Scala black magic extends to file names?
@To-om Don't understand why this didn't break your package build. The up-to-date application.conf is in the latest RC3 packages. 
 