### PR TITLE
Wrong data volume mapping for thehive4 docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - '0.0.0.0:9000:9000'
     volumes:
       - ./thehive/application.conf:/etc/thehive/application.conf
-      - ./data:/data
+      - ./data:/opt/data
     command: '--no-config --no-config-secret'
 
   redis:


### PR DESCRIPTION
TheHive application.conf points to /opt/data for file storage but docker-compose file mounts to /data. This commit fixes the mapping.