### PR TITLE
Add misp thread pool to sample application conf

### DIFF
--- a/conf/application.sample
+++ b/conf/application.sample
@@ -245,3 +245,14 @@ misp {
   #  purpose = ImportAndExport
   #} ## <-- Uncomment to complete the configuration
 }
+
+misp-thread-pool {
+  fork-join-executor {
+    # Min number of threads available for MISP synchronization
+    parallelism-min = 2
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 2.0
+    # Max number of threads available for MISP synchronization
+    parallelism-max = 4
+  }
+}


### PR DESCRIPTION
As the dedicated thread pool for MISP sync was introduced in #1398, this also included an update to the config.
Today I've used the sample config `TheHive/conf/application.sample` to set up a new docker-compose deployment of TheHive with MISP sync.  
The MISP event sync did not work until I added the config section for the thread pool to my config, therefore I recommend this gets added to the sample config to mitigate these issues.

Also, thanks for this great project!