### PR TITLE
Remove duplicate headline

### DIFF
--- a/frontend/app/views/partials/case/case.details.html
+++ b/frontend/app/views/partials/case/case.details.html
@@ -1,6 +1,5 @@
 <div class="row case-details">
     <div class="col-md-8">
-        <h4 class="vpad10 text-primary">Summary</h4>
         <dl class="dl-horizontal clear">
             <dt class="pull-left">Title
             </dt>


### PR DESCRIPTION
Currently there are two sections called summary for closed cases. I think the first one can just be removed as it does not contain additional information for the user.

![Bildschirmfoto 2020-12-16 um 18 43 44](https://user-images.githubusercontent.com/653777/102386259-2404b300-3fcf-11eb-8863-7bd9d5e55802.png)
