### PR TITLE
Added support for Bearer token on Webhook class

### DIFF
--- a/thehive-backend/app/services/WebHook.scala
+++ b/thehive-backend/app/services/WebHook.scala
@@ -9,17 +9,29 @@ import scala.util.{Failure, Success, Try}
 import play.api.{Configuration, Logger}
 import play.api.libs.json.JsObject
 import play.api.libs.ws.WSRequest
+import play.api.http.HeaderNames
 
 import org.elastic4play.services.AuxSrv
 
-case class WebHook(name: String, ws: WSRequest)(implicit ec: ExecutionContext) {
+case class WebHook(name: String, ws: WSRequest, wsToken: Option[String] = None)(implicit ec: ExecutionContext) {
   private[WebHook] lazy val logger = Logger(getClass.getName + "." + name)
 
-  def send(obj: JsObject): Unit = ws.post(obj).onComplete {
-    case Success(resp) if resp.status / 100 != 2 ⇒ logger.error(s"WebHook returns status ${resp.status} ${resp.statusText}")
-    case Failure(_: ConnectException)            ⇒ logger.error(s"Connection to WebHook $name error")
-    case Failure(error)                          ⇒ logger.error("WebHook call error", error)
-    case _                                       ⇒
+  def send(obj: JsObject): Unit = {
+    if (wsToken != None) { 
+      ws.withHttpHeaders(HeaderNames.AUTHORIZATION -> s"Bearer ${wsToken.get}").post(obj).onComplete {
+        case Success(resp) if resp.status / 100 != 2 ⇒ logger.error(s"WebHook returns status ${resp.status} ${resp.statusText}")
+        case Failure(_: ConnectException)            ⇒ logger.error(s"Connection to WebHook $name error")
+        case Failure(error)                          ⇒ logger.error("WebHook call error", error)
+        case _                                       ⇒
+      }
+    } else {
+      ws.post(obj).onComplete {
+        case Success(resp) if resp.status / 100 != 2 ⇒ logger.error(s"WebHook returns status ${resp.status} ${resp.statusText}")
+        case Failure(_: ConnectException)            ⇒ logger.error(s"Connection to WebHook $name error")
+        case Failure(error)                          ⇒ logger.error("WebHook call error", error)
+        case _                                       ⇒
+      }
+    }
   }
 }
 
@@ -31,8 +43,9 @@ class WebHooks(webhooks: Seq[WebHook], auxSrv: AuxSrv, implicit val ec: Executio
       name     ← cfg.subKeys
       whConfig ← Try(cfg.get[Configuration](name)).toOption
       url      ← whConfig.getOptional[String]("url")
+      token      ← Some(whConfig.getOptional[String]("token"))
       instanceWS = whWS.withConfig(whConfig).url(url)
-    } yield WebHook(name, instanceWS)(ec), auxSrv, ec)
+    } yield WebHook(name, instanceWS, token)(ec), auxSrv, ec)
   }
 
   def send(obj: JsObject): Unit =


### PR DESCRIPTION
Webhook class now supports the addition of an optional "token". It needs to be declared at the same level that "url" on the application.conf file. If the parameter exists within a webhook definition, its value will be added to an Authorization header. Else, the send() function of the Webhook class won't include this header on the POST request.

An example of configuration on the application.conf would be as follows:
```
webhooks {
  myLocalWebHook {
    url = "http://localhost/webhook"
    token = "xxxxxxxxxxxxxxxxxx"
  }
}
```
So, in order to test this solution you should:

1. Download and compile the code.
2. Add the webhook configuration to the compiled instance. I attached a demo configuration just for testing purposes.
[PR_Issue-1690-application.conf.txt](https://github.com/TheHive-Project/TheHive/files/5945803/PR_Issue-1690-application.conf.txt)
3. Create and run two different webhooktest.py files, each one on one port so you can receive the same event with and without the bearer token. Also attached to this PR.
[PR_Issue-1690-webhooktest_1.py.txt](https://github.com/TheHive-Project/TheHive/files/5945807/PR_Issue-1690-webhooktest_1.py.txt)
[PR_Issue-1690-webhooktest_2.py.txt](https://github.com/TheHive-Project/TheHive/files/5945809/PR_Issue-1690-webhooktest_2.py.txt)
4. Launch TheHive with the demo configuration file.
5. Check the webhooktest instances to see how it behaves when you add or not the "token" parameter to the configuration.
![PR_Issue-1690_webhook with bearer token](https://user-images.githubusercontent.com/14054703/107262916-6da6d280-6a41-11eb-870c-961169ef09dd.png)
![PR_Issue-1690_webhook without bearer token](https://user-images.githubusercontent.com/14054703/107262924-6ed7ff80-6a41-11eb-8acc-f67f7be44dda.png)

I am a beginner on Scala, so maybe there is an easier way to achieve this goal. In any case, I tested the code and seems to work on TheHive 3.5.0-1 which is the version that I could download from the [build it yourself](https://github.com/TheHive-Project/TheHiveDocs/blob/master/installation/install-guide.md#build-it-yourself) section.
