### PR TITLE
Fix #2050: add max-attributes to misp filters

### DIFF
--- a/misp/connector/src/test/scala/org/thp/thehive/connector/misp/services/TestMispClientProvider.scala
+++ b/misp/connector/src/test/scala/org/thp/thehive/connector/misp/services/TestMispClientProvider.scala
@@ -57,6 +57,7 @@ class TestMispClientProvider @Inject() (Action: DefaultActionBuilder, implicit v
       baseUrl = baseUrl,
       auth = NoAuthentication,
       ws = ws,
+      maxAttributes = None,
       maxAge = None,
       excludedOrganisations = Nil,
       whitelistOrganisations = Nil,


### PR DESCRIPTION
Re add the configuration to filter MISP events on `max-attributes`

The field `max-size` was also present in version 3.5 but is no longer relevant