### PR TITLE
#2058 Fix missing tag when importing alerts from misp

### DIFF
--- a/misp/connector/src/main/scala/org/thp/thehive/connector/misp/services/MispImportSrv.scala
+++ b/misp/connector/src/main/scala/org/thp/thehive/connector/misp/services/MispImportSrv.scala
@@ -72,7 +72,7 @@ class MispImportSrv @Inject() (
           read = false,
           follow = true,
           organisationId = organisationId,
-          tags = event.tags.map(_.name),
+          tags = s"src:${event.orgc}" +: event.tags.map(_.name),
           caseId = EntityId.empty
         )
       }

--- a/misp/connector/src/test/scala/org/thp/thehive/connector/misp/services/MispImportSrvTest.scala
+++ b/misp/connector/src/test/scala/org/thp/thehive/connector/misp/services/MispImportSrvTest.scala
@@ -92,7 +92,7 @@ class MispImportSrvTest(implicit ec: ExecutionContext) extends PlaySpecification
               pap = 2,
               read = false,
               follow = true,
-              tags = Seq("TH-test", "TH-test-2"),
+              tags = Seq("src:ORGNAME", "TH-test", "TH-test-2"),
               organisationId = alert.organisationId,
               caseId = EntityId.empty
             )


### PR DESCRIPTION
Taken from v3 which included this tag: https://github.com/TheHive-Project/TheHive/blob/develop/thehive-misp/app/connectors/misp/JsonFormat.scala#L29

Fixes #2058 