### PR TITLE
#2068 Fix issue where case templates are mixed between orgs

### DIFF
--- a/thehive/app/org/thp/thehive/services/AlertSrv.scala
+++ b/thehive/app/org/thp/thehive/services/AlertSrv.scala
@@ -243,7 +243,7 @@ class AlertSrv @Inject() (
           caseTemplate <-
             alert
               .caseTemplate
-              .map(ct => caseTemplateSrv.get(EntityIdOrName(ct)).richCaseTemplate.getOrFail("CaseTemplate"))
+              .map(ct => caseTemplateSrv.get(EntityIdOrName(ct)).visible.richCaseTemplate.getOrFail("CaseTemplate"))
               .flip
           customField = alert.customFields.map(f => InputCustomFieldValue(f.name, f.value, f.order))
           case0 = Case(


### PR DESCRIPTION
Fixes #2068 : case templates could be selected from an other org if they had the same name when creating a case from an alert