### PR TITLE
Add password policy for local users provider

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,7 +259,8 @@ lazy val thehiveCore = (project in file("thehive"))
       macWireMacros,
       macWireMacrosakka,
       macWireUtil,
-      macWireProxy
+      macWireProxy,
+      passay
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,6 +54,7 @@ object Dependencies {
   lazy val refined                 = "eu.timepit"               %% "refined"                            % "0.9.24"
   lazy val playJsonRefined         = "de.cbley"                 %% "play-json-refined"                  % "0.8.0"
   lazy val playRefined             = "be.venneborg"             %% "play27-refined"                     % "0.6.0"
+  lazy val passay                  = "org.passay"                % "passay"                             % "1.6.0"
 
   def scalaReflect(scalaVersion: String)  = "org.scala-lang" % "scala-reflect"  % scalaVersion
   def scalaCompiler(scalaVersion: String) = "org.scala-lang" % "scala-compiler" % scalaVersion

--- a/thehive/app/org/thp/thehive/controllers/v1/Router.scala
+++ b/thehive/app/org/thp/thehive/controllers/v1/Router.scala
@@ -49,12 +49,13 @@ class Router(
     case POST(p"/admin/schema/info/$schemaName" ? q_o"select=$select" ? q_o"filter=$filter")   => adminCtrl.schemaInfo(schemaName, select, filter)
 
 //    GET      /logout                              controllers.AuthenticationCtrl.logout()
-    case GET(p"/logout")                 => authenticationCtrl.logout
-    case POST(p"/logout")                => authenticationCtrl.logout
-    case POST(p"/login")                 => authenticationCtrl.login
-    case POST(p"/auth/totp/set")         => authenticationCtrl.totpSetSecret
-    case POST(p"/auth/totp/unset")       => authenticationCtrl.totpUnsetSecret(None)
-    case POST(p"/auth/totp/unset/$user") => authenticationCtrl.totpUnsetSecret(Some(user))
+    case GET(p"/logout")                    => authenticationCtrl.logout
+    case POST(p"/logout")                   => authenticationCtrl.logout
+    case POST(p"/login")                    => authenticationCtrl.login
+    case POST(p"/auth/totp/set")            => authenticationCtrl.totpSetSecret
+    case POST(p"/auth/totp/unset")          => authenticationCtrl.totpUnsetSecret(None)
+    case POST(p"/auth/totp/unset/$user")    => authenticationCtrl.totpUnsetSecret(Some(user))
+    case GET(p"/auth/local/passwordPolicy") => authenticationCtrl.localAuthPasswordPolicy
 
     case POST(p"/case")                     => caseCtrl.create
     case GET(p"/case/$caseId")              => caseCtrl.get(caseId)

--- a/thehive/app/org/thp/thehive/services/LocalPasswordAuthSrv.scala
+++ b/thehive/app/org/thp/thehive/services/LocalPasswordAuthSrv.scala
@@ -4,11 +4,12 @@ import io.github.nremond.SecureHash
 import org.thp.scalligraph.auth.{AuthCapability, AuthContext, AuthSrv, AuthSrvProvider}
 import org.thp.scalligraph.models.Database
 import org.thp.scalligraph.utils.Hasher
-import org.thp.scalligraph.{AuthenticationError, AuthorizationError, EntityIdOrName}
+import org.thp.scalligraph.{AuthenticationError, AuthorizationError, BadRequestError, EntityIdOrName}
 import org.thp.thehive.models.User
 import play.api.mvc.RequestHeader
 import play.api.{Configuration, Logger}
 
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 import scala.util.{Failure, Success, Try}
 
 object LocalPasswordAuthSrv {
@@ -17,7 +18,7 @@ object LocalPasswordAuthSrv {
     SecureHash.createHash(password)
 }
 
-class LocalPasswordAuthSrv(db: Database, userSrv: UserSrv, localUserSrv: LocalUserSrv) extends AuthSrv with TheHiveOpsNoDeps {
+class LocalPasswordAuthSrv(db: Database, userSrv: UserSrv, localUserSrv: LocalUserSrv, config: Configuration) extends AuthSrv with TheHiveOpsNoDeps {
   val name                                             = "local"
   override val capabilities: Set[AuthCapability.Value] = Set(AuthCapability.changePassword, AuthCapability.setPassword)
   lazy val logger: Logger                              = Logger(getClass)
@@ -55,17 +56,52 @@ class LocalPasswordAuthSrv(db: Database, userSrv: UserSrv, localUserSrv: LocalUs
       .map(_ => setPassword(username, newPassword))
       .getOrElse(Failure(AuthorizationError("Authentication failure")))
 
-  override def setPassword(username: String, newPassword: String)(implicit authContext: AuthContext): Try[Unit] =
-    db.tryTransaction { implicit graph =>
-      userSrv
-        .get(EntityIdOrName(username))
-        .update(_.password, Some(hashPassword(newPassword)))
-        .getOrFail("User")
-        .map(_ => ())
+  override def setPassword(username: String, newPassword: String)(implicit authContext: AuthContext): Try[Unit] = {
+    for {
+      _ <- checkPasswordPolicy(username, newPassword)
+      _ <- db.tryTransaction { implicit graph =>
+        userSrv
+          .get(EntityIdOrName(username))
+          .update(_.password, Some(hashPassword(newPassword)))
+          .getOrFail("User")
+      }
+    } yield ()
+  }
+
+  private def passwordPolicyEnabled = config.getOptional[Boolean]("passwordPolicy.enabled")
+  private def passwordMinLength = config.getOptional[Int]("passwordPolicy.minLength")
+  private def passwordMinLowerCase = config.getOptional[Int]("passwordPolicy.minLowerCase")
+  private def passwordMinUpperCase = config.getOptional[Int]("passwordPolicy.minUpperCase")
+  private def passwordMinDigit = config.getOptional[Int]("passwordPolicy.minDigit")
+  private def passwordMinSpecial = config.getOptional[Int]("passwordPolicy.minSpecial")
+  private def passwordCannotContainUsername = config.getOptional[Boolean]("passwordPolicy.cannotContainUsername")
+  private def checkPasswordPolicy(username: String, newPassword: String): Try[Unit] = {
+    import org.passay._
+    if (passwordPolicyEnabled.getOrElse(false)) {
+      val rules: Seq[Rule] = Seq(
+        passwordMinLength.map(min => new LengthRule(min, Integer.MAX_VALUE)),
+        passwordMinLowerCase.map(min => new CharacterRule(EnglishCharacterData.LowerCase, min)),
+        passwordMinUpperCase.map(min => new CharacterRule(EnglishCharacterData.UpperCase, min)),
+        passwordMinDigit.map(min => new CharacterRule(EnglishCharacterData.Digit, min)),
+        passwordMinSpecial.map(min => new CharacterRule(EnglishCharacterData.Special, min)),
+        if(passwordCannotContainUsername.getOrElse(false)) Some(new UsernameRule()) else None,
+      ).flatten
+      logger.trace(s"Checking password policy with rules $rules")
+      val passwordValidator = new PasswordValidator(rules:_*)
+      val result = passwordValidator.validate(new PasswordData(username, newPassword))
+      if (result.isValid) Success(())
+      else {
+        val errorMessages = passwordValidator.getMessages(result)
+        Failure(BadRequestError(s"New password does not meet password policy: ${errorMessages.asScala.mkString(", ")}"))
+      }
+    } else {
+      Success(())
     }
+
+  }
 }
 
 class LocalPasswordAuthProvider(db: Database, userSrv: UserSrv, localUserSrv: LocalUserSrv) extends AuthSrvProvider {
   override val name: String                               = "local"
-  override def apply(config: Configuration): Try[AuthSrv] = Success(new LocalPasswordAuthSrv(db, userSrv, localUserSrv))
+  override def apply(config: Configuration): Try[AuthSrv] = Success(new LocalPasswordAuthSrv(db, userSrv, localUserSrv, config))
 }

--- a/thehive/conf/reference.conf
+++ b/thehive/conf/reference.conf
@@ -37,6 +37,19 @@ auth {
     enabled: true
     issuer: TheHive
   }
+  defaults {
+    local {
+      passwordPolicy {
+        enabled = false
+        minLength = 8
+        minLowerCase = 1
+        minUpperCase = 1
+        minDigit = 1
+        minSpecial = 1
+        cannotContainUsername = true
+      }
+    }
+  }
 }
 
 session {


### PR DESCRIPTION
When using the local auth provider, it's possible to define a password policy on several criteria. The policy can be configured through the app configuration.

By default, the password policy is disabled.

This also adds a route `/api/v1/auth/local/passwordPolicy` to get the current configuration which could be used in the UI.