### PR TITLE
Ability to set init-password via ENV

### DIFF
--- a/thehive/app/org/thp/thehive/models/User.scala
+++ b/thehive/app/org/thp/thehive/models/User.scala
@@ -24,7 +24,7 @@ case class User(login: String, name: String, apikey: Option[String], locked: Boo
 }
 
 object User {
-  val initPassword: String = "secret"
+  val initPassword: String = sys.env.getOrElse("THEHIVE_INIT_PASSWORD", "secret")
 
   val init: User = User(
     login = "admin@thehive.local",


### PR DESCRIPTION
Deployments could require to have ability for automated non-factory initial password "secret". With this PR value of initial password could be set via Environment variable "THEHIVE_INIT_PASSWORD".