### PR TITLE
Use lazy val for theHiveModule

### DIFF
--- a/cortex/connector/src/main/scala/org/thp/thehive/connector/cortex/CortexModule.scala
+++ b/cortex/connector/src/main/scala/org/thp/thehive/connector/cortex/CortexModule.scala
@@ -18,12 +18,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
-class CortexModule(app: ScalligraphApplication, theHiveModule: TheHiveModule)
-    extends TheHiveConnector
-    with ScalligraphModule
-    with ActorSingletonUtils {
+class CortexModule(app: ScalligraphApplication) extends TheHiveConnector with ScalligraphModule with ActorSingletonUtils {
 
-  def this(app: ScalligraphApplication) = this(app, app.getModule[TheHiveModule])
   import app._
   import com.softwaremill.macwire._
   import com.softwaremill.macwire.akkasupport._
@@ -97,6 +93,7 @@ class CortexModule(app: ScalligraphApplication, theHiveModule: TheHiveModule)
     theHiveModule.connectors += this
   }
 
+  lazy val theHiveModule: TheHiveModule       = app.getModule[TheHiveModule]
   lazy val cortexActor: ActorRef @@ CortexTag = wireActorSingleton(actorSystem, wireProps[CortexActor], "cortex-actor").taggedWith[CortexTag]
 
   lazy val jobCtrl: JobCtrl                               = wire[JobCtrl]

--- a/misp/connector/src/main/scala/org/thp/thehive/connector/misp/MispModule.scala
+++ b/misp/connector/src/main/scala/org/thp/thehive/connector/misp/MispModule.scala
@@ -17,8 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 sealed trait SyncInterval
 sealed trait SyncInitialDelay
 
-class MispModule(app: ScalligraphApplication, theHiveModule: TheHiveModule) extends TheHiveConnector with ActorSingletonUtils with ScalligraphModule {
-  def this(app: ScalligraphApplication) = this(app, app.getModule[TheHiveModule])
+class MispModule(app: ScalligraphApplication) extends TheHiveConnector with ActorSingletonUtils with ScalligraphModule {
 
   import app._
   import com.softwaremill.macwire._
@@ -87,6 +86,7 @@ class MispModule(app: ScalligraphApplication, theHiveModule: TheHiveModule) exte
     theHiveModule.connectors += this
   }
 
+  lazy val theHiveModule: TheHiveModule   = app.getModule[TheHiveModule]
   lazy val mispImportSrv: MispImportSrv   = wire[MispImportSrv]
   lazy val mispExportSrv: MispExportSrv   = wire[MispExportSrv]
   lazy val mispCtrl: MispCtrl             = wire[MispCtrl]

--- a/thehive/app/org/thp/thehive/controllers/dav/TheHiveFSModule.scala
+++ b/thehive/app/org/thp/thehive/controllers/dav/TheHiveFSModule.scala
@@ -3,11 +3,11 @@ package org.thp.thehive.controllers.dav
 import org.thp.scalligraph.{ScalligraphApplication, ScalligraphModule}
 import org.thp.thehive.TheHiveModule
 
-class TheHiveFSModule(app: ScalligraphApplication, theHiveModule: TheHiveModule) extends ScalligraphModule {
-  def this(app: ScalligraphApplication) = this(app, app.getModule[TheHiveModule])
+class TheHiveFSModule(app: ScalligraphApplication) extends ScalligraphModule {
 
   import com.softwaremill.macwire._
 
-  lazy val vfs: VFS = wire[VFS]
+  lazy val theHiveModule: TheHiveModule = app.getModule[TheHiveModule]
+  lazy val vfs: VFS                     = wire[VFS]
   app.routers += wire[Router].withPrefix("/fs")
 }

--- a/thehive/app/org/thp/thehive/controllers/v0/TheHiveModuleV0.scala
+++ b/thehive/app/org/thp/thehive/controllers/v0/TheHiveModuleV0.scala
@@ -7,11 +7,11 @@ import org.thp.thehive.services.{OrganisationConfigContext, UserConfigContext}
 import play.api.http.HttpErrorHandler
 
 @Module
-class TheHiveModuleV0(app: ScalligraphApplication, theHiveModule: TheHiveModule) extends ScalligraphModule {
-  def this(app: ScalligraphApplication) = this(app, app.getModule[TheHiveModule])
+class TheHiveModuleV0(app: ScalligraphApplication) extends ScalligraphModule {
 
   import com.softwaremill.macwire._
 
+  lazy val theHiveModule: TheHiveModule           = app.getModule[TheHiveModule]
   lazy val authenticationCtrl: AuthenticationCtrl = wire[AuthenticationCtrl]
 
   lazy val alertCtrl: AlertCtrl                       = wire[AlertCtrl]

--- a/thehive/app/org/thp/thehive/controllers/v1/TheHiveModuleV1.scala
+++ b/thehive/app/org/thp/thehive/controllers/v1/TheHiveModuleV1.scala
@@ -5,12 +5,11 @@ import org.thp.thehive.TheHiveModule
 import org.thp.thehive.services._
 import play.api.http.HttpErrorHandler
 
-class TheHiveModuleV1(app: ScalligraphApplication, theHiveModule: TheHiveModule) extends ScalligraphModule {
-
-  def this(app: ScalligraphApplication) = this(app, app.getModule[TheHiveModule])
+class TheHiveModuleV1(app: ScalligraphApplication) extends ScalligraphModule {
 
   import com.softwaremill.macwire._
 
+  lazy val theHiveModule: TheHiveModule           = app.getModule[TheHiveModule]
   lazy val authenticationCtrl: AuthenticationCtrl = wire[AuthenticationCtrl]
 
   lazy val alertCtrl: AlertCtrl                             = wire[AlertCtrl]


### PR DESCRIPTION
The module list in `ScalligraphApplication` does not really have an order so to avoid issues when `TheHiveModule` is loaded last, a `lazy val` is used for it