### PR TITLE
Don't add current user to the created organisation in api v1

### DIFF
--- a/thehive/app/org/thp/thehive/controllers/v1/OrganisationCtrl.scala
+++ b/thehive/app/org/thp/thehive/controllers/v1/OrganisationCtrl.scala
@@ -55,8 +55,8 @@ class OrganisationCtrl(
       .authPermittedTransaction(db, Permissions.manageOrganisation) { implicit request => implicit graph =>
         val inputOrganisation: InputOrganisation = request.body("organisation")
         for {
-          user         <- userSrv.current.getOrFail("User")
-          organisation <- organisationSrv.create(inputOrganisation.toOrganisation, user)
+          _            <- userSrv.current.organisations(Permissions.manageOrganisation).get(EntityName(Organisation.administration.name)).existsOrFail
+          organisation <- organisationSrv.create(inputOrganisation.toOrganisation)
         } yield Results.Created(organisation.toJson)
       }
 

--- a/thehive/app/org/thp/thehive/services/OrganisationSrv.scala
+++ b/thehive/app/org/thp/thehive/services/OrganisationSrv.scala
@@ -46,12 +46,6 @@ class OrganisationSrv(
 
   override def getByName(name: String)(implicit graph: Graph): Traversal.V[Organisation] = startTraversal.getByName(name)
 
-  def create(organisation: Organisation, user: User with Entity)(implicit graph: Graph, authContext: AuthContext): Try[Organisation with Entity] =
-    for {
-      createdOrganisation <- create(organisation)
-      _                   <- roleSrv.create(user, createdOrganisation, profileSrv.orgAdmin)
-    } yield createdOrganisation
-
   def create(e: Organisation)(implicit graph: Graph, authContext: AuthContext): Try[Organisation with Entity] = {
     val activeTaxos = getByName("admin").taxonomies.toSeq
     for {


### PR DESCRIPTION
With the api v1 when creating an org, the current user was added to the organisation. This behavior was different from v0 api where no user was added to the org