### PR TITLE
Fix Typo in Attack Pattern Import confirmation

### DIFF
--- a/frontend/app/scripts/controllers/admin/attack/AttackPatternListCtrl.js
+++ b/frontend/app/scripts/controllers/admin/attack/AttackPatternListCtrl.js
@@ -163,7 +163,7 @@
                 .catch(function (response) {
                     NotificationSrv.error('AttackPatternImportCtrl', response.data, response.status);
                 })
-                .fincally(function () {
+                .finally(function () {
                     this.loading = false;
                 });
         };


### PR DESCRIPTION
Fixes a typo that caused the Attack Pattern import flow not to return correctly. 