### PR TITLE
Fix: Unsorted Custom Fields in case UI bug

### DIFF
--- a/thehive/app/org/thp/thehive/services/CaseSrv.scala
+++ b/thehive/app/org/thp/thehive/services/CaseSrv.scala
@@ -126,8 +126,8 @@ class CaseSrv @Inject() (
     val uniqueFields = caseTemplateCf.filter {
       case InputCustomFieldValue(name, _, _) => !caseCf.exists(_.name == name)
     }
-    (caseCf ++ uniqueFields)
-      .sortBy(cf => (cf.order.isEmpty, cf.order))
+    
+    (caseCf.sortBy(_.order) ++ uniqueFields.sortBy(_.order))
       .zipWithIndex
       .map { case (InputCustomFieldValue(name, value, _), i) => InputCustomFieldValue(name, value, Some(i)) }
   }


### PR DESCRIPTION
Hello,
There is a bug when creating case via case creation API.
When creating case via API, user custom fields and template custom fields, all the custom fields together are seems shuffled. example:

test-template.json:
```
{
    "_id":"~40976408",
    "createdBy":"ido@thehive.local"
    ,"createdAt":1642595224777,
    "_type":"caseTemplate",
    "name":"test-template",
    "displayName":"",
    "titlePrefix":"",
    "description":"test-template",
    "severity":2,
    "tags":[],
    "flag":false,
    "tlp":2,
    "pap":2,
    "tasks":[],
    "status":"Ok",
    "customFields":
    {
        "template-field2":{"string":"rty","order":2},
        "template-field1":{"string":"qwe","order":1},
        "template-field3":{"string":"uio","order":3},
        "template-field4":{"string":"asd","order":4}
    },
    "metrics":{}
}
```

When creating case with case-creation.py (using thehive4py package):
```
from thehive4py.api import TheHiveApi
from thehive4py.models import Case, CaseTask, CustomFieldHelper

api = TheHiveApi('http://localhost:9000', '####')
customFields = CustomFieldHelper()\
    .add_string('user-field1', '123')\
    .add_string('user-field2', '456')\
    .add_string('user-field3', '789')\
    .add_string('user-field4', 'abc')\
    .build()

case = Case(title='From TheHive4Py',
            tlp=3,
            pap=3,
            flag=True,
            tags=['TheHive4Py', 'sample'],
            description='N/A',
            template='test-template',
            customFields=customFields)
response = api.create_case(case)
```

The output case custom fields looks like:

<img width="370" alt="Screen Shot 2022-01-19 at 14 43 13" src="https://user-images.githubusercontent.com/47807648/150133158-0a9e5f16-c2be-4ff8-86ae-9da10f9e6d4b.png">


The bug is because the 'caseCf' variable (user custom fields) has order field in each object, and the order value is the order 
of lines which in the case-creation.py CustomFieldHelper function (translates to incremental order field in the array when using rest API) starting from 0 ('user-field1' order value is 0, 'user-field2' order value is 1 and so on).
In addition the 'uniqueFields' variable (template custom fields) has order field in object too, the order is which custom field you added first in template starting from 1 (for example in our case 'template-field1' order is 1, 'template-field2' order is 2...)  

When sorting them together by order it explains the looks of the screenshot:
user-field1 | order=0
user-field2 | order=1
user-template1 | order=1
user-field3 | order=2
user-template2 | order=2
user-field4 | order=3
user-template3 | order=3
user-template4 | order=4

My solution for this was to 'sortBy' the template custom fields and the user custom fields by '_.order' field in separate, and then concat the Seq together, removing the 'sortBy' after the concation.